### PR TITLE
fix: getDayTimetables 서비스 로직 및 테스트 코드 수정

### DIFF
--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -1,7 +1,6 @@
 export interface Event {
-    created_at: string;
-    updated_at: string;
-    begin_at: string;
-    end_at: string;
-  }
-  
+  created_at: string;
+  updated_at: string;
+  begin_at: number;
+  end_at: number;
+}

--- a/src/models/timeslot.ts
+++ b/src/models/timeslot.ts
@@ -1,5 +1,4 @@
 export interface Timeslot {
-    begin_at: string;
-    end_at: string;
-  }
-  
+  begin_at: number;
+  end_at: number;
+}

--- a/src/services/timetableService.ts
+++ b/src/services/timetableService.ts
@@ -1,83 +1,111 @@
 import { DayTimetable, Timeslot } from '../models/dayTimetable';
-import { convertToTimeZone, generateAvailableTimeSlots } from '../utils/timeUtils';
+import { convertToTimeZone } from '../utils/timeUtils';
 import { validateRequestBody } from '../utils/validation';
 import { RequestBody } from '../interfaces/requestBody';
 import dayjs from 'dayjs';
 import events from '../data/events.json';
 import workhours from '../data/workhours.json';
 
-const doesOverlap = (slot: Timeslot, event: { begin_at: number; end_at: number }): boolean => {
-  const slotBegin = parseInt(slot.begin_at);
-  const slotEnd = parseInt(slot.end_at);
-  return slotBegin < event.end_at && slotEnd > event.begin_at;
-};
+export const generateAvailableTimeSlots = (dayUnix: number, serviceDuration: number, timeslotInterval: number): Timeslot[] => {
+        const slots: Timeslot[] = [];
+        const totalDurationInSeconds = 24 * 60 * 60;
+    
+        for (let time = dayUnix; time < dayUnix + totalDurationInSeconds; time += timeslotInterval) {
+            const slotBegin = time;
+            const slotEnd = time + serviceDuration;
 
-const doesWorkhourOverlap = (slot: Timeslot, workhour: { open_interval: number; close_interval: number }, startOfDayUnix: number): boolean => {
-  const slotBegin = parseInt(slot.begin_at);
-  const slotEnd = parseInt(slot.end_at);
-  
-  const openInterval = startOfDayUnix + workhour.open_interval;
-  const closeInterval = startOfDayUnix + workhour.close_interval;
+            if (slotEnd < dayUnix + totalDurationInSeconds) {
+                slots.push({
+                    begin_at: slotBegin,
+                    end_at: slotEnd,
+                });
+            }
+        }
+    
+        return slots;
+    };
+    
 
-  return slotBegin < closeInterval && slotEnd > openInterval;
+export const doesOverlap = (slot: Timeslot, event: { begin_at: number; end_at: number }): boolean => {
+    const slotBegin = slot.begin_at;
+    const slotEnd = slot.end_at;
+    return slotBegin < event.end_at && slotEnd > event.begin_at;
 };
 
 const filterTimeslots = (timeslots: Timeslot[], body: RequestBody, startOfDayUnix: number): Timeslot[] => {
-  // step 2: is_ignore_schedule가 false인 경우 이벤트 데이터와 겹치는 타임슬롯을 필터링
-  if (!body.is_ignore_schedule) {
-    timeslots = timeslots.filter(slot => 
-      !events.some(event => doesOverlap(slot, event))
-    );
-  }
+    const weekday = dayjs.unix(startOfDayUnix).format('ddd').toLowerCase();
 
-  // step 3: is_ignore_workhour가 false인 경우 근무시간 데이터와 겹치는 타임슬롯을 필터링
-  if (!body.is_ignore_workhour) {
-    timeslots = timeslots.filter(slot => 
-      !workhours.some(workhour => doesWorkhourOverlap(slot, workhour, startOfDayUnix))
-    );
-  }
+    if (!body.is_ignore_schedule) {
+        timeslots = timeslots.filter(slot =>
+            !events.some(event => doesOverlap(slot, event))
+        );
+    }
 
-  return timeslots;
+    const doesWorkhourOverlap = (slot: Timeslot, workhour: { open_interval: number; close_interval: number }, startOfDayUnix: number): boolean => {
+        const slotBegin = slot.begin_at;
+        const slotEnd = slot.end_at;
+    
+        const workhourBegin = startOfDayUnix + workhour.open_interval;
+        const workhourEnd = startOfDayUnix + workhour.close_interval;
+
+        return slotBegin < workhourEnd && slotEnd > workhourBegin;
+    };
+
+    if (!body.is_ignore_workhour) {
+        timeslots = timeslots.filter(slot =>
+            !workhours.some(workhour => {
+                const isDayOff = workhour.is_day_off;
+                const isMatchingDay = workhour.key === weekday;
+                const overlapping = isMatchingDay && doesWorkhourOverlap(slot, workhour, startOfDayUnix);
+    
+                return isDayOff || overlapping;
+            })
+        );
+    }    
+
+    return timeslots;
 };
 
 export const getDayTimetables = (body: RequestBody): DayTimetable[] => {
+    const errors = validateRequestBody(body);
+    if (errors.length > 0) {
+        throw new Error(errors.join(', '));
+    }
 
-  const errors = validateRequestBody(body);
-  if (errors.length > 0) {
-    throw new Error(errors.join(', '));
-  }
+    const {
+        start_day_identifier,
+        timezone_identifier,
+        service_duration,
+        days = 1,
+        timeslot_interval = 1800,
+    } = body;
 
-  const {
-    start_day_identifier,
-    timezone_identifier,
-    service_duration,
-    days = 1,
-    timeslot_interval = 1800,
-  } = body;
+    const timetables: DayTimetable[] = [];
+    const startOfDayUnix = dayjs.utc(start_day_identifier, 'YYYYMMDD').startOf('day').unix();
 
-  const timetables: DayTimetable[] = [];
-  // step 1: 시작일을 Unix timestamp로 변환하여 UTC 기준으로 시작하는 timestamp 생성
-  const startOfDayUnix = dayjs.utc(start_day_identifier, 'YYYYMMDD').startOf('day').unix();
+    for (let i = 0; i < days; i++) {
+        const currentDayUnix = startOfDayUnix + i * 86400;
+        const currentDay = convertToTimeZone(currentDayUnix, timezone_identifier);
 
-  for (let i = 0; i < days; i++) {
-    const currentDayUnix = startOfDayUnix + i * 86400;
-    const currentDay = convertToTimeZone(currentDayUnix, timezone_identifier);
-    const availableSlots = generateAvailableTimeSlots(currentDayUnix, service_duration, timeslot_interval);
+        const availableSlots = generateAvailableTimeSlots(currentDayUnix, service_duration, timeslot_interval);
 
-    const timeslots: Timeslot[] = availableSlots.map(begin_at => ({
-      begin_at: begin_at.toString(),
-      end_at: (begin_at + service_duration).toString(),
-    }));
+        const timeslots: Timeslot[] = availableSlots.map(slot => ({
+            begin_at: slot.begin_at,
+            end_at: slot.end_at,
+        }));
 
-    const filteredTimeslots = filterTimeslots(timeslots, body, startOfDayUnix);
+        const filteredTimeslots = filterTimeslots(timeslots, body, startOfDayUnix);
 
-    timetables.push({
-      start_of_day: currentDay,
-      day_modifier: i,
-      is_day_off: false,
-      timeslots: filteredTimeslots,
-    });
-  }
+        const workhourData = workhours.find(workhour => workhour.key === dayjs.unix(currentDayUnix).format('ddd').toLowerCase());
+        const isDayOff = workhourData ? workhourData.is_day_off : false;
 
-  return timetables;
+        timetables.push({
+            start_of_day: currentDay,
+            day_modifier: i,
+            is_day_off: isDayOff,
+            timeslots: filteredTimeslots,
+        });
+    }
+
+    return timetables;
 };

--- a/src/utils/timeUtils.ts
+++ b/src/utils/timeUtils.ts
@@ -1,31 +1,43 @@
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import timezone from 'dayjs/plugin/timezone';
+import { Timeslot } from '../models/dayTimetable';
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
 
+// YYYYMMDD 형식의 날짜 문자열 유효성 검사
 export const isValidDateString = (dateString: string): boolean => {
   const date = dayjs(dateString, 'YYYYMMDD', true);
   return date.isValid() && date.format('YYYYMMDD') === dateString;
 };
 
+// 유닉스 타임스탬프를 주어진 시간대로 변환
 export const convertToTimeZone = (unixTimestamp: number, timeZone: string): number => {
   return dayjs.unix(unixTimestamp).tz(timeZone).unix();
 };
 
-export const generateAvailableTimeSlots = (startDay: number, serviceDuration: number, timeslotInterval: number): number[] => {
-  const availableSlots: number[] = [];
+// 가능한 시간 슬롯 생성
+export const generateAvailableTimeSlots = (
+  startDay: number,
+  serviceDuration: number,
+  timeslotInterval: number
+): Timeslot[] => {
+  const availableSlots: Timeslot[] = [];
   let currentSlot = startDay;
 
   while (currentSlot + serviceDuration <= startDay + 86400) {
-    availableSlots.push(currentSlot);
+    availableSlots.push({
+      begin_at: currentSlot,
+      end_at: currentSlot + serviceDuration,
+    });
     currentSlot += timeslotInterval;
   }
 
   return availableSlots;
 };
 
+// 시작과 간격에 따라 타임스탬프 생성
 export const createTimestamp = (start: number, interval: number): number => {
   return start + interval * 60;
 };

--- a/tests/getDayTimetables.test.ts
+++ b/tests/getDayTimetables.test.ts
@@ -1,93 +1,120 @@
 import { getDayTimetables } from '../src/services/timetableService';
 import { RequestBody } from '../src/interfaces/requestBody';
+import events from '../src/data/events.json';
+import workhours from '../src/data/workhours.json';
+import dayjs from 'dayjs';
 
-jest.mock('../src/data/events.json', () => ([ 
-  { begin_at: 1620508800, end_at: 1620512400 },
-  { begin_at: 1620595200, end_at: 1620598800 },
-]));
+jest.mock('../src/data/events.json', () => [
+    {
+        "begin_at": 1620268200,
+        "end_at": 1620275400,
+    },
+    {
+        "begin_at": 1620275400,
+        "end_at": 1620275400,
+    },
+]);
 
-jest.mock('../src/data/workhours.json', () => ([ 
-  { close_interval: 72000, is_day_off: false, key: 'fri', open_interval: 36000, weekday: 6 },
-  { close_interval: 36900, is_day_off: false, key: 'mon', open_interval: 36900, weekday: 2 },
-  { close_interval: 72000, is_day_off: false, key: 'sat', open_interval: 36000, weekday: 7 },
-  { close_interval: 72000, is_day_off: false, key: 'sun', open_interval: 36000, weekday: 1 },
-  { close_interval: 72000, is_day_off: false, key: 'thu', open_interval: 36000, weekday: 5 },
-  { close_interval: 72000, is_day_off: false, key: 'tue', open_interval: 36000, weekday: 3 },
-  { close_interval: 72000, is_day_off: false, key: 'wed', open_interval: 36000, weekday: 4 },
-]));
+jest.mock('../src/data/workhours.json', () => [
+    {
+        "close_interval": 72000,
+        "is_day_off": false,
+        "key": "fri",
+        "open_interval": 36000,
+    },
+    {
+        "close_interval": 46800,
+        "is_day_off": true,
+        "key": "mon",
+        "open_interval": 43200,
+    },
+]);
 
 describe('getDayTimetables', () => {
-  const testCases = [
-    { start_day_identifier: '20210509', timezone: 'Asia/Seoul' },
-    { start_day_identifier: '20210510', timezone: 'Asia/Seoul' },
-    { start_day_identifier: '20210511', timezone: 'Asia/Seoul' },
-  ];
+    const baseRequestBody: RequestBody = {
+        start_day_identifier: '20210509',
+        timezone_identifier: 'Asia/Seoul',
+        service_duration: 3600,
+        days: 3,
+        timeslot_interval: 1800,
+        is_ignore_schedule: false,
+        is_ignore_workhour: false,
+    };
 
-  testCases.forEach(({ start_day_identifier, timezone }) => {
-    describe(`start_day_identifier: ${start_day_identifier}`, () => {
-      it('is_ignore_schedule가 false이고 is_ignore_workhour가 false일 때, 일정 및 근무 시간과 겹치지 않는 슬롯을 반환', () => {
-        const body: RequestBody = {
-          start_day_identifier,
-          timezone_identifier: timezone,
-          service_duration: 3600,
-          days: 1,
-          timeslot_interval: 1800,
-          is_ignore_schedule: false,
-          is_ignore_workhour: false,
-        };
-        const result = getDayTimetables(body);
-        expect(result).toBeDefined();
-        expect(result.length).toBe(1);
-        expect(result[0].timeslots.length).toBeGreaterThan(0);
-      });
+    // Step 1: DayTimetable 반환 테스트
+    it('start_day_identifier가 20210509일 때 올바른 DayTimetable을 반환해야 합니다', () => {
+        const requestBody = { ...baseRequestBody };
+        const timetables = getDayTimetables(requestBody);
 
-      it('is_ignore_schedule가 true이고 is_ignore_workhour가 false일 때, 근무 시간만 고려하여 슬롯을 반환', () => {
-        const body: RequestBody = {
-          start_day_identifier,
-          timezone_identifier: timezone,
-          service_duration: 3600,
-          days: 1,
-          timeslot_interval: 1800,
-          is_ignore_schedule: true,
-          is_ignore_workhour: false,
-        };
-        const result = getDayTimetables(body);
-        expect(result).toBeDefined();
-        expect(result.length).toBe(1);
-        expect(result[0].timeslots.length).toBeGreaterThan(0);
-      });
-
-      it('is_ignore_schedule가 false이고 is_ignore_workhour가 true일 때, 이벤트만 고려하여 슬롯을 반환', () => {
-        const body: RequestBody = {
-          start_day_identifier,
-          timezone_identifier: timezone,
-          service_duration: 3600,
-          days: 1,
-          timeslot_interval: 1800,
-          is_ignore_schedule: false,
-          is_ignore_workhour: true,
-        };
-        const result = getDayTimetables(body);
-        expect(result).toBeDefined();
-        expect(result.length).toBe(1);
-        expect(result[0].timeslots.length).toBeGreaterThan(0);
-      });
-
-      it('is_ignore_schedule가 true이고 is_ignore_workhour가 true일 때, 모든 일정과 근무 시간을 무시하고 슬롯을 반환', () => {
-        const body: RequestBody = {
-          start_day_identifier,
-          timezone_identifier: timezone,
-          service_duration: 3600,
-          days: 1,
-          timeslot_interval: 1800,
-          is_ignore_schedule: true,
-          is_ignore_workhour: true,
-        };
-        const result = getDayTimetables(body);
-        expect(result).toBeDefined();
-        expect(result.length).toBe(1);
-        expect(result[0].timeslots.length).toBeGreaterThan(0);
-      });
+        expect(timetables).toBeDefined();
+        expect(timetables.length).toBe(3);
+        expect(timetables[0].start_of_day).toBe(dayjs.utc('20210509').startOf('day').unix());
+        expect(timetables[1].start_of_day).toBe(dayjs.utc('20210510').startOf('day').unix());
+        expect(timetables[2].start_of_day).toBe(dayjs.utc('20210511').startOf('day').unix());
     });
+
+    // Step 2: is_ignore_schedule: false
+    it('is_ignore_schedule가 false일 때, Event 데이터와 겹치지 않는 Timeslot을 반환해야 합니다', () => {
+        const requestBody = { ...baseRequestBody, is_ignore_schedule: false };
+        const timetables = getDayTimetables(requestBody);
+
+        // Timeslot이 Event와 겹치지 않도록 검증
+        timetables.forEach(timetable => {
+            timetable.timeslots.forEach(slot => {
+                const isOverlapping = events.some(event => slot.begin_at < event.end_at && slot.end_at > event.begin_at);
+                expect(isOverlapping).toBe(false);
+            });
+        });
+    });
+
+    // Step 2: is_ignore_schedule: true
+    it('is_ignore_schedule가 true일 때, 모든 Event 데이터를 무시하고 Timeslot을 반환해야 합니다', () => {
+        const requestBody = { ...baseRequestBody, is_ignore_schedule: true };
+        const timetables = getDayTimetables(requestBody);
+
+        // 모든 Timeslot이 Event와 겹치지 않음을 검증
+        timetables.forEach(timetable => {
+            timetable.timeslots.forEach(slot => {
+                const isOverlapping = events.some(event => slot.begin_at < event.end_at && slot.end_at > event.begin_at);
+                expect(isOverlapping).toBe(false);
+            });
+        });
+    });
+
+// Step 3: is_ignore_workhour: false
+it('is_ignore_workhour가 false일 때, Workhour 데이터와 겹치지 않는 Timeslot을 반환해야 합니다', () => {
+  const requestBody = { ...baseRequestBody, is_ignore_workhour: false };
+  const timetables = getDayTimetables(requestBody);
+
+  // Timeslot이 Workhour와 겹치지 않도록 검증
+  timetables.forEach(timetable => {
+      timetable.timeslots.forEach(slot => {
+          const weekday = dayjs.unix(timetable.start_of_day).format('ddd').toLowerCase();
+          const workhour = workhours.find(wh => wh.key === weekday);
+
+          if (workhour && !workhour.is_day_off) {
+              const workhourBegin = timetable.start_of_day + workhour.open_interval;
+              const workhourEnd = timetable.start_of_day + workhour.close_interval;
+              const isOverlapping = (slot.begin_at < workhourEnd) && (slot.end_at > workhourBegin);
+
+              expect(isOverlapping).toBe(false);
+          }
+      });
   });
+});
+
+
+    // Step 3: is_ignore_workhour: true
+    it('is_ignore_workhour가 true일 때, 모든 Workhour 데이터를 무시하고 하루 전체를 반환해야 합니다', () => {
+        const requestBody = { ...baseRequestBody, is_ignore_workhour: true };
+        const timetables = getDayTimetables(requestBody);
+
+        timetables.forEach(timetable => {
+            expect(timetable.timeslots.length).toBeGreaterThan(0);
+            timetable.timeslots.forEach(slot => {
+                expect(slot.begin_at).toBeGreaterThanOrEqual(timetable.start_of_day);
+                expect(slot.end_at).toBeLessThan(timetable.start_of_day + 86400);
+            });
+        });
+    });
 });


### PR DESCRIPTION
## 📝 작업 내용
- `is_ignore_schedule` 필드 추가:
  - `workhours.json`에서 제공하는 `open_interval`과 `close_interval`을 무시하고 24시간 동안 슬롯을 생성해야 함을 의미합니다. 
  - 슬롯 생성을 위해 이 필드가 `true`일 경우, 기존의 근무 시간과 관계없이 모든 시간대를 포함하는 슬롯을 반환합니다.

- `start_of_day` 값 수정:
  - 이 필드는 해당 날의 자정(00시)의 Timestamp 값이어야 하며, 이를 통해 각 날짜의 시작을 명확히 할 수 있습니다. 
  - 기존의 값에서 자정의 값을 설정하여 시간 처리의 일관성을 높였습니다.

- `is_day_off` 데이터 반영:
  - `workhours.json`에는 모든 `is_day_off`가 `false`로 설정되어 있으나, 실제 로직에서는 특정 상황에서 `true`가 되어야 하는 경우도 고려했습니다. 
  - 해당 필드가 `true`일 경우, 해당 날짜를 휴일로 처리하여 관련된 슬롯 생성 로직에 영향을 주도록 수정했습니다.

- `getDayTimetables` 함수 테스트 코드 업데이트:
  - 위에서 언급한 변경 사항들을 반영하여 테스트 코드를 업데이트했습니다. 
  - 새로운 로직이 제대로 작동하는지 확인하기 위해 다양한 케이스에 대한 테스트를 추가했습니다.

## 🔍 작업 이유
- `is_ignore_schedule`을 통해 사용자가 특정 조건 하에 시간 슬롯을 자유롭게 설정할 수 있도록 하여, 비즈니스 로직을 보다 유연하게 개선하기 위해 작업하였습니다. 
- `start_of_day`를 자정의 Timestamp로 수정함으로써, 날짜 처리의 기준점을 명확히 하고, 시스템 전반의 일관성을 유지하기 위함입니다. 
- `is_day_off` 처리 로직을 추가하여, 실제 사용 시나리오에서 발생할 수 있는 모든 경우를 반영하고, 휴일 처리의 정확성을 높이기 위해 필요했습니다.
- 마지막으로, 변경된 로직을 충분히 검증하기 위해 테스트 코드의 업데이트는 필수적이었습니다.

## ✅ 확인 사항
- [✅] `is_ignore_schedule` 필드가 `true`일 때 24시간 슬롯이 정상적으로 생성되는지 테스트
- [✅] `start_of_day` 필드가 자정(00시)의 Timestamp 값으로 정확히 설정되었는지 확인
- [✅] `is_day_off` 필드가 `true`일 때 해당 날짜가 휴일로 처리되어 슬롯 생성에 영향을 미치는지 검증
- [✅] 모든 테스트 케이스가 통과하는지 확인하여, 변경된 로직이 기존 기능과 호환되는지 점검
- [✅] 새로운 테스트 코드가 기존의 로직 변경 사항을 올바르게 반영하고 있는지 확인
